### PR TITLE
ham: Mount debugfs on early-init

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -16,6 +16,9 @@ import /init.qcom.usb.rc
 import /init.qcom.power.rc
 
 on early-init
+    mount debugfs debugfs /sys/kernel/debug
+    chmod 0755 /sys/kernel/debug
+
     chown system system /sys/kernel/debug/kgsl/proc
 
 on init


### PR DESCRIPTION
This was mounted in the global init.rc in Android 6.0.

In Android 7.0 however, this is no longer the case.
Hence, revive the mount.

This was cherry-picked from the Bacon CM Gerrit: https://review.cyanogenmod.org/#/c/166089/